### PR TITLE
Store karma in a sqlite database

### DIFF
--- a/lib/POE/Component/IRC/Plugin/ReKarma.pm
+++ b/lib/POE/Component/IRC/Plugin/ReKarma.pm
@@ -238,7 +238,7 @@ sub S_public {
             );
 
             %karma = DBI_select_all($dbh, "ASC", $num_records);
-            my @bottom_keys = sort { $karma{$a} > $karma{$b} } keys %karma;;
+            my @bottom_keys = sort { $karma{$a} <= $karma{$b} } keys %karma;;
 
             $irc->yield(
                 notice => $channel,
@@ -267,7 +267,9 @@ sub S_public {
 
 sub DESTROY {
     my $self = shift;
-    DBI_close($self->{dbh});
+    if (defined $self->{dbh}) {
+        DBI_close($self->{dbh});
+    }
 }
 
 1;

--- a/lib/POE/Component/IRC/Plugin/ReKarma.pm
+++ b/lib/POE/Component/IRC/Plugin/ReKarma.pm
@@ -115,7 +115,7 @@ sub DBI_select_all {
 
 sub DBI_close {
     my $dbh = shift;
-    my $res = $dbh->disconnect() or warn "DBI::errstr";
+    my $res = $dbh->disconnect() or warn "$DBI::errstr";
     return $res
 }
 

--- a/lib/POE/Component/IRC/Plugin/ReKarma.pm
+++ b/lib/POE/Component/IRC/Plugin/ReKarma.pm
@@ -249,7 +249,7 @@ sub S_public {
                 $irc->yield(
                     notice => $channel,
                     "karma for <$_> is " . %bottom_karma{$_},
-                ) for @bottom_keys;
+                ) for reverse @bottom_keys;
             }
         }
     } else {

--- a/lib/POE/Component/IRC/Plugin/ReKarma.pm
+++ b/lib/POE/Component/IRC/Plugin/ReKarma.pm
@@ -49,11 +49,10 @@ use constant {
 
 use DBI;
 
-# TODO these should be moved to a module. But where?
+# TODO(gmodena) these should be moved to a module. But where?
 sub DBI_init {
     my $dbname = shift;
 
-    # TODO: maybe connect_cached?
     my $dbh = DBI->connect("dbi:SQLite:dbname=$dbname","","", {
         RaiseError => 1,
         PrintError => 1,
@@ -86,9 +85,6 @@ sub DBI_upsert_score {
 
 sub DBI_select_score {
     my ($dbh, $what) = @_;
-
-    # TODO(gmodena): we should lowercase records at insertion time (and set constraints) 
-    # in the bulk-load python script.
     my $sth = $dbh->prepare(q{
         SELECT Score FROM Karmas WHERE Name = ?;
         });
@@ -146,7 +142,7 @@ sub get_or_create_dbh {
     if (! defined $self->{dbh}) {
         $self->{dbh} = DBI_init($dbname);
     } elsif ($self->{dbh}->sqlite_db_filename ne $dbname) {
-        warn "Replacing datbase " . $self->{dbh}->sqlite_db_filename . " with " . $dbname;
+        warn "Replacing database " . $self->{dbh}->sqlite_db_filename . " with " . $dbname;
         $self->{dbh}->disconnect;
         $self->{dbh} = DBI_init($dbname); 
     }
@@ -238,7 +234,7 @@ sub S_public {
             );
 
             %karma = DBI_select_all($dbh, "ASC", $num_records);
-            my @bottom_keys = sort { $karma{$a} <= $karma{$b} } keys %karma;;
+            my @bottom_keys = sort { $karma{$a} <= $karma{$b} } keys %karma;
 
             $irc->yield(
                 notice => $channel,
@@ -267,7 +263,7 @@ sub S_public {
 
 sub DESTROY {
     my $self = shift;
-    if (defined $self->{dbh}) {
+    if ( defined $self->{dbh} ) {
         DBI_close($self->{dbh});
     }
 }


### PR DESCRIPTION
This PR adds support to a sqlite backend for karma.

A karma database must be specified by setting `$channel_settings->{status_file}`. 

Karma is stored with the following schema:
```
CREATE TABLE IF NOT EXISTS "Karmas" ( 
    "Name" TEXT NOT NULL CONSTRAINT "PK_Karmas"PRIMARY KEY, 
    "Score" INTEGER NOT NULL );
```
`Karmas` will be created if not found in the database file.

## Dependencies
This PR adds a dependency on `DBD::SQLite`.